### PR TITLE
Add missing package `react-router`

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
         "codemirror": "^5.61.1",
         "echarts": "^4.9.0",
         "echarts-for-react": "^2.0.16",
+        "forge-dataviz-iot-data-modules": "0.1.10",
+        "forge-dataviz-iot-react-components": "0.1.16",
         "lodash": "^4.17.15",
         "moment": "^2.27.0",
         "pixi.js": "^5.3.7",
@@ -55,11 +57,10 @@
         "react-copy-to-clipboard": "^5.0.3",
         "react-dates": "^21.8.0",
         "react-rnd": "^10.2.1",
+        "react-router": "5.2.0",
         "react-router-dom": "5.2.0",
         "socket.io": "^3.0.4",
         "socket.io-client": "^3.0.4",
-        "uuid": "^8.3.2",
-        "forge-dataviz-iot-data-modules": "0.1.10",
-        "forge-dataviz-iot-react-components": "0.1.16"
+        "uuid": "^8.3.2"
     }
 }


### PR DESCRIPTION
Need to lock the `react-router` version to `5.2.0` to resolve the `Cannot resolve react-router package`  issue.